### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mcp-server-duckdb
+[![smithery badge](https://smithery.ai/badge/mcp-server-duckdb)](https://smithery.ai/server/mcp-server-duckdb)
 
 A Model Context Protocol (MCP) server implementation for DuckDB, providing database interaction capabilities through MCP tools.
 It would be interesting to have LLM analyze it. DuckDB is suitable for local analysis.
@@ -65,6 +66,14 @@ This ensures that the Language Model (LLM) cannot perform any modifications to t
 
 
 ## Installation
+
+### Installing via Smithery
+
+To install DuckDB Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-duckdb):
+
+```bash
+npx -y @smithery/cli install mcp-server-duckdb --client claude
+```
 
 ### Claude Desktop Integration
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install DuckDB Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-server-duckdb

Let me know if any tweaks have to be made!