### PR TITLE
fix #4: Correct readonly mode logic in write operations

### DIFF
--- a/src/mcp_server_duckdb/__init__.py
+++ b/src/mcp_server_duckdb/__init__.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 
 from mcp_server_duckdb.config import Config
@@ -8,13 +7,6 @@ from . import server
 
 def main():
     """Main entry point for the package."""
-
-    parser = argparse.ArgumentParser(description="DuckDB MCP Server")
-    parser.add_argument(
-        "--db-path",
-        help="Path to DuckDB database file",
-        required=True,
-    )
 
     config = Config.from_arguments()
     asyncio.run(server.main(config))

--- a/src/mcp_server_duckdb/server.py
+++ b/src/mcp_server_duckdb/server.py
@@ -187,7 +187,7 @@ async def main(config: Config):
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "write-query":
-                if not config.readonly:
+                if config.readonly:
                     raise ValueError("Server is running in read-only mode")
                 if arguments["query"].strip().upper().startswith("SELECT"):
                     raise ValueError("SELECT queries are not allowed for write-query")
@@ -195,7 +195,7 @@ async def main(config: Config):
                 return [types.TextContent(type="text", text=str(results))]
 
             elif name == "create-table":
-                if not config.readonly:
+                if config.readonly:
                     raise ValueError("Server is running in read-only mode")
                 if not arguments["query"].strip().upper().startswith("CREATE TABLE"):
                     raise ValueError("Only CREATE TABLE statements are allowed")


### PR DESCRIPTION
Fix #4 

Fixed the conditional logic error.

Before:
Writes were blocked even when `readonly` was not set.

After:
Writes are now allowed when `readonly` is not set.